### PR TITLE
ci: only publish when release-please cut a release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,7 +42,13 @@ jobs:
 
   publish:
     needs: release-please
-    if: ${{ always() && (needs.release-please.outputs.release_created || inputs.publish_only) }}
+    # release-please's `releases_created` output is a STRING ("true"/"false"),
+    # so a bare truthy check fires on every push (even when no release was
+    # created) and ends in E403 trying to re-publish the existing version.
+    # Compare to the literal 'true' string to only publish when release-please
+    # actually cut a release. publish_only is a real boolean from
+    # workflow_dispatch input, so it can stay as-is.
+    if: ${{ always() && (needs.release-please.outputs.release_created == 'true' || inputs.publish_only == true) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Bare-truthy check on `release_created` (which is a string "true"/"false") was firing publish on every push, leading to E403s trying to re-publish the existing version. Compare to the literal `'true'` string instead.

Same fix going to meridian-plugin-opencode-scrub. Will also benefit from being applied to the main meridian repo (which has the same bug — failures just hidden in the run history).