### PR TITLE
fix: scrub pi fingerprints on all adapters (content-scoped)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - uses: oven-sh/setup-bun@v2
+
       - run: npm ci
+      - run: bun test
       - run: npm run build
 
       # Pack the tarball so we catch any `files` / `.npmignore` regressions

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "bun test"
   },
   "keywords": [
     "meridian",

--- a/src/__tests__/scrub.test.ts
+++ b/src/__tests__/scrub.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "bun:test"
+import { scrubPiFingerprints } from "../scrub.js"
+
+/**
+ * Fixtures mirror buildSystemPrompt() in pi-coding-agent
+ * packages/coding-agent/src/core/system-prompt.ts (verified against 0.80.6):
+ * identity line, tools, guidelines, "Pi documentation" block, optional
+ * <project_context>, then `\nCurrent date: ...\nCurrent working directory: ...`
+ * appended with SINGLE newlines.
+ */
+
+const IDENTITY =
+  "You are an expert coding assistant operating inside pi, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.\n"
+
+const BODY = `
+Available tools:
+- read: Read files
+- bash: Execute commands
+
+In addition to the tools above, you may have access to other custom tools depending on the project.
+
+Guidelines:
+- Be concise in your responses
+- Show file paths clearly when working with files
+
+`
+
+const DOCS_BLOCK = `Pi documentation (read only when the user asks about pi itself, its SDK, extensions, themes, skills, or TUI):
+- Main documentation: /home/user/.pi/node_modules/@earendil-works/pi-coding-agent/README.md
+- Additional docs: /home/user/.pi/node_modules/@earendil-works/pi-coding-agent/docs
+- Examples: /home/user/.pi/node_modules/@earendil-works/pi-coding-agent/examples (extensions, custom tools, SDK)
+- When reading pi docs or examples, resolve docs/... under Additional docs and examples/... under Examples, not the current working directory
+- When asked about: extensions (docs/extensions.md, examples/extensions/), themes (docs/themes.md), skills (docs/skills.md), prompt templates (docs/prompt-templates.md), TUI components (docs/tui.md), keybindings (docs/keybindings.md), SDK integrations (docs/sdk.md), custom providers (docs/custom-provider.md), adding models (docs/models.md), pi packages (docs/packages.md)
+- When working on pi topics, read the docs and examples, and follow .md cross-references before implementing
+- Always read pi .md files completely and follow links to related docs (e.g., tui.md for TUI API details)`
+
+const PROJECT_CONTEXT = `
+
+<project_context>
+
+Project-specific instructions and guidelines:
+
+<project_instructions path="/repo/AGENTS.md">
+Follow the house style.
+</project_instructions>
+
+</project_context>
+`
+
+const TAIL = "\nCurrent date: 7/10/2026\nCurrent working directory: /repo"
+
+/** No context files, no skills — docs block runs straight into the tail. */
+const MINIMAL_PROMPT = IDENTITY + BODY + DOCS_BLOCK + TAIL
+
+/** Common case — <project_context> (which starts with \n\n) follows the docs block. */
+const FULL_PROMPT = IDENTITY + BODY + DOCS_BLOCK + PROJECT_CONTEXT + TAIL
+
+describe("scrubPiFingerprints", () => {
+  it("replaces the pi identity line with the generic one", () => {
+    const out = scrubPiFingerprints(FULL_PROMPT)
+    expect(out).not.toContain("operating inside pi, a coding agent harness")
+    expect(out).toContain("You are an expert coding assistant.")
+  })
+
+  it("removes the Pi documentation block", () => {
+    const out = scrubPiFingerprints(FULL_PROMPT)
+    expect(out).not.toContain("Pi documentation")
+    expect(out).not.toContain("pi-coding-agent")
+  })
+
+  it("preserves project context, guidelines, and tools", () => {
+    const out = scrubPiFingerprints(FULL_PROMPT)
+    expect(out).toContain("<project_context>")
+    expect(out).toContain("Follow the house style.")
+    expect(out).toContain("Be concise in your responses")
+    expect(out).toContain("Available tools:")
+  })
+
+  it("preserves the date and cwd lines when nothing follows the docs block", () => {
+    // Regression: with no context files/skills, the docs-block regex used to
+    // fall through to $ and swallow the single-newline-separated tail.
+    const out = scrubPiFingerprints(MINIMAL_PROMPT)
+    expect(out).toContain("Current date: 7/10/2026")
+    expect(out).toContain("Current working directory: /repo")
+    expect(out).not.toContain("Pi documentation")
+  })
+
+  it("preserves the date and cwd lines in the common case too", () => {
+    const out = scrubPiFingerprints(FULL_PROMPT)
+    expect(out).toContain("Current date: 7/10/2026")
+    expect(out).toContain("Current working directory: /repo")
+  })
+
+  it("is a no-op on prompts without pi fingerprints", () => {
+    const clean = "You are Claude Code, Anthropic's official CLI for Claude.\n\nDo things well."
+    expect(scrubPiFingerprints(clean)).toBe(clean)
+  })
+
+  it("is idempotent", () => {
+    const once = scrubPiFingerprints(FULL_PROMPT)
+    expect(scrubPiFingerprints(once)).toBe(once)
+    const onceMinimal = scrubPiFingerprints(MINIMAL_PROMPT)
+    expect(scrubPiFingerprints(onceMinimal)).toBe(onceMinimal)
+  })
+
+  it("returns empty input unchanged", () => {
+    expect(scrubPiFingerprints("")).toBe("")
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,15 @@
 /**
  * Meridian plugin: strip pi-identifying fingerprints from the system prompt.
  *
- * Scoped to the `pi` adapter so it's a no-op for other agents. Runs on every
- * pi request — the scrub is idempotent, so even for already-scrubbed inputs
- * (e.g. fork/subagent replays) it produces identical output.
+ * CONTENT-SCOPED, not adapter-scoped: runs on EVERY adapter and self-scopes by
+ * content. `scrubPiFingerprints` only rewrites the prompt when pi's identity
+ * fingerprint (e.g. "operating inside pi, a coding agent harness") is actually
+ * present, and is otherwise an exact no-op. This matters because pi's prompt can
+ * arrive under a NON-pi adapter — Pylon, for instance, routes pi traffic as
+ * `adapter=opencode`, so an adapter-scoped `["pi"]` filter would miss it and let
+ * the fingerprint reach Claude (which Anthropic meters as agentic/Extra-Usage
+ * traffic). Running everywhere + the idempotent regex is safe for genuine
+ * Claude Code / OpenCode prompts (no match → unchanged).
  */
 
 import type { Transform, RequestContext } from "./types.js"
@@ -16,9 +22,10 @@ export type { Transform, RequestContext } from "./types.js"
 
 const plugin: Transform = {
   name: "pi-scrub",
-  version: "0.1.0",
-  description: "Strip pi-identifying fingerprints from the system prompt before it reaches Claude",
-  adapters: ["pi"],
+  version: "0.2.0",
+  description: "Strip pi-identifying fingerprints from the system prompt before it reaches Claude (all adapters; content-scoped)",
+  // No `adapters` restriction — undefined means all adapters. The scrub is a
+  // content-based no-op when no pi fingerprint is present.
 
   onRequest(ctx: RequestContext): RequestContext {
     if (!ctx.systemContext) return ctx

--- a/src/scrub.ts
+++ b/src/scrub.ts
@@ -31,11 +31,18 @@ const PI_IDENTITY_LINE =
 
 /**
  * Pi's "Pi documentation" block. Starts with the header line and runs until
- * the next double-newline (section boundary) or end of string. Matches the
- * ~10-line block referencing pi SDK / extensions / themes / skills / TUI /
- * keybindings / prompt-templates / custom-provider / models / packages.
+ * the next double-newline (section boundary), the single-newline-separated
+ * "Current date:" tail, or end of string. Matches the ~10-line block
+ * referencing pi SDK / extensions / themes / skills / TUI / keybindings /
+ * prompt-templates / custom-provider / models / packages.
+ *
+ * The "\nCurrent date:" alternative matters when the prompt has no context
+ * files, no skills, and no appendSystemPrompt: buildSystemPrompt appends
+ * `\nCurrent date: ...\nCurrent working directory: ...` with single newlines,
+ * so without it the lazy match runs to $ and swallows those lines too.
  */
-const PI_DOCS_BLOCK = /Pi documentation \(read only when[\s\S]*?(?=\n\n|$)/
+const PI_DOCS_BLOCK =
+  /Pi documentation \(read only when[\s\S]*?(?=\n\n|\nCurrent date:|$)/
 
 /**
  * Anthropic-preset-style `<env>` block + its preamble. Claude Code's preset

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": [
+      "ES2022"
+    ],
     "strict": true,
     "skipLibCheck": true,
     "noEmit": false,
@@ -16,5 +18,11 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/__tests__/**"
+  ]
 }


### PR DESCRIPTION
The published 0.2.0 scopes the scrub to `adapters: ["pi"]`, but pi traffic can arrive under a non-pi adapter — Pylon routes pi requests as `adapter=opencode` — so the filter never fires and the "operating inside pi, a coding agent harness" identity line reaches Claude, which Anthropic meters as agentic/Extra-Usage traffic.

Drop the adapter restriction so the scrub runs everywhere. `scrubPiFingerprints` is an exact no-op when no pi fingerprint is present, so genuine Claude Code / OpenCode prompts are unaffected.

(This commit was authored 2026-06-08 but never pushed — the npm 0.2.0 release does not contain it.)