### PR TITLE
fix: keep scrubPiFingerprints an exact no-op without a pi fingerprint

### DIFF
--- a/src/__tests__/scrub.test.ts
+++ b/src/__tests__/scrub.test.ts
@@ -96,6 +96,29 @@ describe("scrubPiFingerprints", () => {
     expect(scrubPiFingerprints(clean)).toBe(clean)
   })
 
+  // index.ts registers this plugin for every adapter, so a prompt with no pi
+  // fingerprint must come back byte-identical. The fixture above happens to
+  // contain neither a 3+ newline run nor trailing whitespace, so it could not
+  // catch the unconditional cleanup passes.
+  it("is a no-op on a foreign prompt containing runs of 3+ newlines", () => {
+    const clean = "You are a helpful assistant.\n\n\n## Section\n\n\n\nBody text."
+    expect(scrubPiFingerprints(clean)).toBe(clean)
+  })
+
+  it("is a no-op on a foreign prompt with trailing whitespace", () => {
+    const clean = "You are a helpful assistant.\n\nBody text.\n\n"
+    expect(scrubPiFingerprints(clean)).toBe(clean)
+  })
+
+  it("still normalizes whitespace when a pi fingerprint was removed", () => {
+    // The cleanup passes exist to repair the gaps the removals leave behind,
+    // so they must keep running whenever a removal actually happened.
+    const out = scrubPiFingerprints(FULL_PROMPT)
+    expect(out).not.toContain("\n\n\n")
+    expect(out).not.toMatch(/\s$/)
+    expect(out).not.toContain("operating inside pi")
+  })
+
   it("is idempotent", () => {
     const once = scrubPiFingerprints(FULL_PROMPT)
     expect(scrubPiFingerprints(once)).toBe(once)

--- a/src/scrub.ts
+++ b/src/scrub.ts
@@ -75,6 +75,12 @@ const GENERIC_IDENTITY =
  * - Collapses runs of 3+ newlines to 2 so section spacing stays normal
  * - Trims trailing whitespace-only lines
  *
+ * The last two only run when one of the removals above actually matched. They
+ * exist to repair the gaps those removals leave, so applying them to a prompt
+ * that had no pi fingerprint would mutate it for no reason — and index.ts
+ * registers this plugin for EVERY adapter on the explicit promise that such a
+ * prompt comes back unchanged.
+ *
  * Preserves: tools list, guidelines, date/cwd, pylon/user-appended content,
  * subagent-specific prompt body, project context files, skills block.
  *
@@ -83,10 +89,11 @@ const GENERIC_IDENTITY =
  */
 export function scrubPiFingerprints(systemPrompt: string): string {
   if (!systemPrompt) return systemPrompt
-  return systemPrompt
+  const stripped = systemPrompt
     .replace(PI_IDENTITY_LINE, GENERIC_IDENTITY)
     .replace(PI_DOCS_BLOCK, "")
     .replace(DUPLICATE_ENV_PREAMBLE_BLOCK, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .replace(/\s+$/, "")
+  // Nothing pi-specific was found: return the input untouched.
+  if (stripped === systemPrompt) return systemPrompt
+  return stripped.replace(/\n{3,}/g, "\n\n").replace(/\s+$/, "")
 }


### PR DESCRIPTION
## Problem

The two cleanup passes at the end of `scrubPiFingerprints` run unconditionally:

```ts
.replace(/\n{3,}/g, "\n\n")
.replace(/\s+$/, "")
```

They exist to repair the gaps the removals above leave behind, but they apply to *every* prompt — including prompts with no pi fingerprint at all. Any prompt containing a run of 3+ newlines or trailing whitespace comes back modified.

## Why it matters

Since #4 the plugin is deliberately registered for **every adapter** and self-scopes by content. `src/index.ts` states the contract explicitly:

> `scrubPiFingerprints` only rewrites the prompt when pi's identity fingerprint … is actually present, and is otherwise an exact no-op.

That contract is load-bearing now: the plugin sees Claude Code, OpenCode and other harnesses' system prompts and quietly reflows all of them. `index.ts` also only propagates a new context when the string changed:

```ts
const scrubbed = scrubPiFingerprints(ctx.systemContext);
if (scrubbed === ctx.systemContext) return ctx;
```

so on any realistically-sized foreign prompt the guard never short-circuits and the plugin appears to act on essentially every request.

Impact is a silent, unnecessary mutation rather than a crash — deterministic, so it doesn't churn the prompt cache. Being straight about severity: I found this while chasing an unrelated Extra Usage rejection and **verified this was not its cause**. Filing it because the no-op guarantee is the plugin's justification for running everywhere.

## Fix

Gate the cleanup on one of the removals having matched. Whitespace normalization still runs whenever a fingerprint was actually removed, so the original intent is preserved.

## Tests

The suite already asserted this guarantee (`is a no-op on prompts without pi fingerprints`), but its fixture contains neither a 3+ newline run nor trailing whitespace, so it could not catch the violation. Added two fixtures that do, plus one asserting the cleanup still runs on a real pi prompt.

```
before fix:  9 pass, 2 fail
after fix:  11 pass, 0 fail
```

`tsc --noEmit` clean.